### PR TITLE
[feat]: 이메일로 주문 내역 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -28,7 +28,7 @@ public class OrdersController {
         return "email_form";
     }
 
-    @GetMapping
+    @GetMapping("/email")
     public String viewOrders(@Validated @ModelAttribute EmailDto request,
         BindingResult bindingResult, @RequestParam(defaultValue = "0") int page, Model model) {
         if (bindingResult.hasErrors()) {

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -33,7 +33,6 @@ public class OrdersController {
             return "email_form";
         }
         List<Orders> orders = ordersService.getOrdersByEmail(request.getEmail());
-        System.out.println(orders);
         model.addAttribute("orders", orders);
         return "view_orders";
     }

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @RequestMapping("/orders")
@@ -33,7 +34,21 @@ public class OrdersController {
             return "email_form";
         }
         List<Orders> orders = ordersService.getOrdersByEmail(request.getEmail());
+
+        model.addAttribute("email", request.getEmail());
         model.addAttribute("orders", orders);
+        model.addAttribute("request", "email");
+
+        return "view_orders";
+    }
+
+    @GetMapping("/id")
+    public String viewOrderById(@RequestParam Long orderId, Model model) {
+        List<Orders> orders = ordersService.getOrderById(orderId);
+
+        model.addAttribute("orders", orders);
+        model.addAttribute("request", "id");
+
         return "view_orders";
     }
 }

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -5,6 +5,8 @@ import com.example.gridscircles.domain.order.entity.Orders;
 import com.example.gridscircles.domain.order.service.OrdersService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -28,15 +30,18 @@ public class OrdersController {
 
     @GetMapping
     public String viewOrders(@Validated @ModelAttribute EmailDto request,
-        BindingResult bindingResult, Model model) {
+        BindingResult bindingResult, @RequestParam(defaultValue = "0") int page, Model model) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("error", "이메일 형식이 올바르지 않습니다.");
             return "email_form";
         }
-        List<Orders> orders = ordersService.getOrdersByEmail(request.getEmail());
+        String email = request.getEmail();
+        Page<Orders> ordersPage = ordersService.getOrdersByEmail(email, PageRequest.of(page, 6));
 
-        model.addAttribute("email", request.getEmail());
-        model.addAttribute("orders", orders);
+        model.addAttribute("email", email);
+        model.addAttribute("orders", ordersPage.getContent());
+        model.addAttribute("currentPage", page);
+        model.addAttribute("totalPages", ordersPage.getTotalPages());
         model.addAttribute("request", "email");
 
         return "view_orders";

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -30,7 +30,7 @@ public class OrdersController {
         BindingResult bindingResult, Model model) {
         if (bindingResult.hasErrors()) {
             model.addAttribute("error", "이메일 형식이 올바르지 않습니다.");
-            return "error";
+            return "email_form";
         }
         List<Orders> orders = ordersService.getOrdersByEmail(request.getEmail());
         System.out.println(orders);

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -1,0 +1,40 @@
+package com.example.gridscircles.domain.order.controller;
+
+import com.example.gridscircles.domain.order.dto.EmailDto;
+import com.example.gridscircles.domain.order.entity.Orders;
+import com.example.gridscircles.domain.order.service.OrdersService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrdersController {
+
+    private final OrdersService ordersService;
+
+    @GetMapping("/search")
+    public String searchForm() {
+        return "email_form";
+    }
+
+    @GetMapping
+    public String viewOrders(@Validated @ModelAttribute EmailDto request,
+        BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            model.addAttribute("error", "이메일 형식이 올바르지 않습니다.");
+            return "error";
+        }
+        List<Orders> orders = ordersService.getOrdersByEmail(request.getEmail());
+        System.out.println(orders);
+        model.addAttribute("orders", orders);
+        return "view_orders";
+    }
+}

--- a/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/OrdersController.java
@@ -43,8 +43,9 @@ public class OrdersController {
     }
 
     @GetMapping("/id")
-    public String viewOrderById(@RequestParam Long orderId, Model model) {
-        List<Orders> orders = ordersService.getOrderById(orderId);
+    public String viewOrderById(@RequestParam Long orderId,
+        @RequestParam(required = false) String email, Model model) {
+        List<Orders> orders = ordersService.getOrderById(orderId, email);
 
         model.addAttribute("orders", orders);
         model.addAttribute("request", "id");

--- a/src/main/java/com/example/gridscircles/domain/order/dto/EmailDto.java
+++ b/src/main/java/com/example/gridscircles/domain/order/dto/EmailDto.java
@@ -1,0 +1,15 @@
+package com.example.gridscircles.domain.order.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailDto {
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Email(message = "올바른 이메일 형식이어야 합니다.")
+    private String email;
+}

--- a/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
@@ -2,13 +2,16 @@ package com.example.gridscircles.domain.order.repository;
 
 import com.example.gridscircles.domain.order.entity.Orders;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
 
-    List<Orders> findByEmailOrderByCreatedAtDesc(String email);
+    Page<Orders> findByEmailOrderByCreatedAtDesc(String email, Pageable pageable);
 
     List<Orders> findByIdAndEmailOrderByCreatedAt(Long id, String email);
+
 }

--- a/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
@@ -10,5 +10,5 @@ public interface OrdersRepository extends JpaRepository<Orders, Long> {
 
     List<Orders> findByEmailOrderByCreatedAtDesc(String email);
 
-    List<Orders> findByIdOrderByCreatedAtDesc(Long id);
+    List<Orders> findByIdAndEmailOrderByCreatedAt(Long id, String email);
 }

--- a/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
@@ -1,9 +1,12 @@
 package com.example.gridscircles.domain.order.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.example.gridscircles.domain.order.entity.Orders;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
 
+    List<Orders> findByEmailOrderByCreatedAtDesc(String email);
 }

--- a/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/gridscircles/domain/order/repository/OrdersRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface OrdersRepository extends JpaRepository<Orders, Long> {
 
     List<Orders> findByEmailOrderByCreatedAtDesc(String email);
+
+    List<Orders> findByIdOrderByCreatedAtDesc(Long id);
 }

--- a/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
+++ b/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
@@ -15,4 +15,8 @@ public class OrdersService {
     public List<Orders> getOrdersByEmail(String email) {
         return ordersRepository.findByEmailOrderByCreatedAtDesc(email);
     }
+
+    public List<Orders> getOrderById(Long id) {
+        return ordersRepository.findByIdOrderByCreatedAtDesc(id);
+    }
 }

--- a/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
+++ b/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
@@ -16,7 +16,7 @@ public class OrdersService {
         return ordersRepository.findByEmailOrderByCreatedAtDesc(email);
     }
 
-    public List<Orders> getOrderById(Long id) {
-        return ordersRepository.findByIdOrderByCreatedAtDesc(id);
+    public List<Orders> getOrderById(Long id, String email) {
+        return ordersRepository.findByIdAndEmailOrderByCreatedAt(id, email);
     }
 }

--- a/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
+++ b/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
@@ -4,6 +4,8 @@ import com.example.gridscircles.domain.order.entity.Orders;
 import com.example.gridscircles.domain.order.repository.OrdersRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,8 +14,8 @@ public class OrdersService {
 
     private final OrdersRepository ordersRepository;
 
-    public List<Orders> getOrdersByEmail(String email) {
-        return ordersRepository.findByEmailOrderByCreatedAtDesc(email);
+    public Page<Orders> getOrdersByEmail(String email, Pageable pageable) {
+        return ordersRepository.findByEmailOrderByCreatedAtDesc(email, pageable);
     }
 
     public List<Orders> getOrderById(Long id, String email) {

--- a/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
+++ b/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
@@ -1,0 +1,18 @@
+package com.example.gridscircles.domain.order.service;
+
+import com.example.gridscircles.domain.order.entity.Orders;
+import com.example.gridscircles.domain.order.repository.OrdersRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrdersService {
+
+    private final OrdersRepository ordersRepository;
+
+    public List<Orders> getOrdersByEmail(String email) {
+        return ordersRepository.findByEmailOrderByCreatedAtDesc(email);
+    }
+}

--- a/src/main/resources/templates/email_form.html
+++ b/src/main/resources/templates/email_form.html
@@ -60,7 +60,7 @@
 
 <div class="form-container">
     <h1>주문 내역 조회</h1>
-    <form th:action="@{/orders}" method="get">
+    <form th:action="@{/orders/email}" method="get">
         <label for="email">이메일</label><br/>
         <input type="email" id="email" name="email" required><br/>
         <button type="submit">조회하기</button>

--- a/src/main/resources/templates/email_form.html
+++ b/src/main/resources/templates/email_form.html
@@ -3,15 +3,69 @@
 <head>
     <meta charset="UTF-8">
     <title>주문 조회</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Arial', sans-serif;
+            background-color: #f8f9fa;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+        }
+
+        .form-container {
+            background-color: #eeeeee;
+            padding: 40px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            width: 500px;
+        }
+
+        .form-container h1 {
+            margin-bottom: 20px;
+            font-size: 1.5em;
+        }
+
+        .form-container input[type="email"] {
+            width: 100%;
+            padding: 12px;
+            margin-top: 10px;
+            margin-bottom: 20px;
+            border: 1px solid #ccc;
+            border-radius: 8px;
+            font-size: 1em;
+            box-sizing: border-box;
+        }
+
+
+        .form-container button {
+            padding: 12px 24px;
+            background-color: #444444;
+            border: none;
+            color: white;
+            border-radius: 8px;
+            font-size: 1em;
+            cursor: pointer;
+        }
+
+        .form-container button:hover {
+            background-color: #2f2f2f;
+        }
+    </style>
 </head>
 <body>
-<h1>주문 조회</h1>
 
-<form th:action="@{/orders}" method="get">
-    <label for="email">이메일:</label>
-    <input type="email" id="email" name="email" required>
-    <button type="submit">조회하기</button>
-</form>
+<div class="form-container">
+    <h1>주문 내역 조회</h1>
+    <form th:action="@{/orders}" method="get">
+        <label for="email">이메일</label><br/>
+        <input type="email" id="email" name="email" required><br/>
+        <button type="submit">조회하기</button>
+    </form>
+</div>
 
 </body>
 </html>

--- a/src/main/resources/templates/email_form.html
+++ b/src/main/resources/templates/email_form.html
@@ -1,0 +1,18 @@
+<!-- templates/email_form.html -->
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>주문 조회</title>
+</head>
+<body>
+<h1>주문 조회</h1>
+
+<form th:action="@{/orders}" method="get">
+    <label for="email">이메일:</label>
+    <input type="email" id="email" name="email" required>
+    <button type="submit">조회하기</button>
+</form>
+
+</body>
+</html>

--- a/src/main/resources/templates/email_form.html
+++ b/src/main/resources/templates/email_form.html
@@ -1,4 +1,3 @@
-<!-- templates/email_form.html -->
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -18,10 +18,10 @@
   </thead>
   <tbody>
   <tr th:each="order : ${orders}">
-    <td th:text="${order.getId()}">1</td>
-    <td th:text="${order.getTotalPrice()}">2000</td>
-    <td th:text="${order.getOrderStatus()}">배송중</td>
-    <td th:text="${order.getCreatedAt()}">2025-04-23</td>
+    <td th:text="${order.getId()}"></td>
+    <td th:text="${order.getTotalPrice()}"></td>
+    <td th:text="${order.getOrderStatus()}"></td>
+    <td th:text="${order.getCreatedAt()}"></td>
   </tr>
   </tbody>
 </table>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -86,6 +86,20 @@
     a.button:hover {
       background-color: #333;
     }
+
+    .pagination a {
+      margin: 0 5px;
+      text-decoration: none;
+      color: #444;
+      padding: 6px 12px;
+      border-radius: 6px;
+    }
+
+    .pagination a.button {
+      background-color: #444;
+      color: white;
+      pointer-events: none;
+    }
   </style>
 </head>
 <body>
@@ -120,6 +134,15 @@
     </tr>
     </tbody>
   </table>
+
+  <div class="pagination" style="text-align: center; margin-top: 20px;" th:if="${totalPages > 1}">
+    <div style="display: inline-block;">
+      <a th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+         th:href="@{/orders(email=${email}, page=${i})}"
+         th:text="${i + 1}"
+         th:classappend="${i == currentPage} ? ' button' : ''"></a>
+    </div>
+  </div>
 
   <div style="text-align: center;">
     <a th:if="${request == 'email'}" href="/orders/search" class="button">돌아가기</a>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -107,8 +107,8 @@
   <h1 th:text="${email != null} ? ${email} + '님의 주문 내역' : '주문 내역'">주문 내역</h1>
 
   <form class="search-form" th:action="@{/orders/id}" method="get">
-    <input type="hidden" name="email" th:value="${email}"/>
     <input type="number" name="orderId" placeholder="주문 ID" required>
+    <input type="hidden" name="email" th:value="${email}"/>
     <button type="submit">조회</button>
   </form>
 

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>주문 내역</title>
+</head>
+<body>
+<h1>주문 내역</h1>
+
+<table border="1">
+  <thead>
+  <tr>
+    <th>주문 ID</th>
+    <th>가격</th>
+    <th>주문 상태</th>
+    <th>주문일</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="order : ${orders}">
+    <td th:text="${order.getId()}">1</td>
+    <td th:text="${order.getTotalPrice()}">2000</td>
+    <td th:text="${order.getOrderStatus()}">배송중</td>
+    <td th:text="${order.getCreatedAt()}">2025-04-23</td>
+  </tr>
+  </tbody>
+</table>
+
+<a href="/orders/search">돌아가기</a>
+
+</body>
+</html>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -138,7 +138,7 @@
   <div class="pagination" style="text-align: center; margin-top: 20px;" th:if="${totalPages > 1}">
     <div style="display: inline-block;">
       <a th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
-         th:href="@{/orders(email=${email}, page=${i})}"
+         th:href="@{/orders/email(email=${email}, page=${i})}"
          th:text="${i + 1}"
          th:classappend="${i == currentPage} ? ' button' : ''"></a>
     </div>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -3,34 +3,92 @@
 <head>
   <meta charset="UTF-8">
   <title>주문 내역</title>
+  <style>
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      background-color: #f2f2f2;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      margin: 0;
+    }
+
+    .container {
+      background-color: #ffffff;
+      padding: 40px;
+      border-radius: 16px;
+      box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+      width: 80%;
+      max-width: 900px;
+    }
+
+    h1 {
+      text-align: center;
+      margin-bottom: 30px;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      border: 1px solid #ccc;
+      padding: 12px;
+      text-align: center;
+    }
+
+    th {
+      background-color: #f0f0f0;
+    }
+
+    a.button {
+      display: inline-block;
+      margin-top: 20px;
+      padding: 10px 20px;
+      background-color: #444;
+      color: white;
+      text-decoration: none;
+      border-radius: 8px;
+      text-align: center;
+    }
+
+    a.button:hover {
+      background-color: #333;
+    }
+  </style>
 </head>
 <body>
-<h1>주문 내역</h1>
+<div class="container">
+  <h1>주문 내역</h1>
 
-<table border="1">
-  <thead>
-  <tr>
-    <th>주문 ID</th>
-    <th>주소</th>
-    <th>우편번호</th>
-    <th>총 가격</th>
-    <th>주문 상태</th>
-    <th>주문일</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr th:each="order : ${orders}">
-    <td th:text="${order.getId()}"></td>
-    <td th:text="${order.getAddress()}"></td>
-    <td th:text="${order.getZipcode()}"></td>
-    <td th:text="${order.getTotalPrice()}"></td>
-    <td th:text="${order.getOrderStatus()}"></td>
-    <td th:text="${order.getCreatedAt()}"></td>
-  </tr>
-  </tbody>
-</table>
+  <table>
+    <thead>
+    <tr>
+      <th>주문 ID</th>
+      <th>주소</th>
+      <th>우편번호</th>
+      <th>총 가격</th>
+      <th>주문 상태</th>
+      <th>주문일</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr th:each="order : ${orders}">
+      <td th:text="${order.getId()}"></td>
+      <td th:text="${order.getAddress()}"></td>
+      <td th:text="${order.getZipcode()}"></td>
+      <td th:text="${order.getTotalPrice()}"></td>
+      <td th:text="${order.getOrderStatus()}"></td>
+      <td th:text="${order.getCreatedAt()}"></td>
+    </tr>
+    </tbody>
+  </table>
 
-<a href="/orders/search">돌아가기</a>
-
+  <div style="text-align: center;">
+    <a href="/orders/search" class="button">돌아가기</a>
+  </div>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -28,6 +28,35 @@
       margin-bottom: 30px;
     }
 
+    .search-form {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 30px;
+      gap: 10px;
+    }
+
+    .search-form input[type="number"] {
+      padding: 10px;
+      font-size: 16px;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      width: 200px;
+    }
+
+    .search-form button {
+      background-color: #444;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      padding: 10px 20px;
+      font-size: 16px;
+      cursor: pointer;
+    }
+
+    .search-form button:hover {
+      background-color: #333;
+    }
+
     table {
       width: 100%;
       border-collapse: collapse;
@@ -61,7 +90,12 @@
 </head>
 <body>
 <div class="container">
-  <h1>주문 내역</h1>
+  <h1 th:text="${email != null} ? ${email} + '님의 주문 내역' : '주문 내역'">주문 내역</h1>
+
+  <form class="search-form" th:action="@{/orders/id}" method="get">
+    <input type="number" name="orderId" placeholder="주문 ID" required>
+    <button type="submit">조회</button>
+  </form>
 
   <table>
     <thead>
@@ -87,7 +121,8 @@
   </table>
 
   <div style="text-align: center;">
-    <a href="/orders/search" class="button">돌아가기</a>
+    <a th:if="${request == 'email'}" href="/orders/search" class="button">돌아가기</a>
+    <a th:if="${request == 'id'}" href="javascript:history.back()" class="button">돌아가기</a>
   </div>
 </div>
 </body>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -93,6 +93,7 @@
   <h1 th:text="${email != null} ? ${email} + '님의 주문 내역' : '주문 내역'">주문 내역</h1>
 
   <form class="search-form" th:action="@{/orders/id}" method="get">
+    <input type="hidden" name="email" th:value="${email}"/>
     <input type="number" name="orderId" placeholder="주문 ID" required>
     <button type="submit">조회</button>
   </form>

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -11,7 +11,9 @@
   <thead>
   <tr>
     <th>주문 ID</th>
-    <th>가격</th>
+    <th>주소</th>
+    <th>우편번호</th>
+    <th>총 가격</th>
     <th>주문 상태</th>
     <th>주문일</th>
   </tr>
@@ -19,6 +21,8 @@
   <tbody>
   <tr th:each="order : ${orders}">
     <td th:text="${order.getId()}"></td>
+    <td th:text="${order.getAddress()}"></td>
+    <td th:text="${order.getZipcode()}"></td>
     <td th:text="${order.getTotalPrice()}"></td>
     <td th:text="${order.getOrderStatus()}"></td>
     <td th:text="${order.getCreatedAt()}"></td>


### PR DESCRIPTION
## ✨ 설명
- #2 
- 주문 시 입력한 이메일로 주문 내역을 최신순으로 불러오는 기능을 구현했습니다.
    - 주문 내역을 6개 단위로 볼 수 있도록 페이징 처리를 했습니다.
![image](https://github.com/user-attachments/assets/6de7c7fe-735a-4ca9-92ce-d8a9634be258)
![image](https://github.com/user-attachments/assets/37d5f3d7-5e56-4474-b6a1-eb12201bcc4b)

- 조회 시 입력한 문자열이 이메일 형식이 아니거나, 비어있다면 예외처리를 진행했습니다.
    - 이 때, spring-boot-starter-validation 의존성을 추가했습니다.
![image](https://github.com/user-attachments/assets/4159e37f-2775-4e75-a461-ebab5dc828a7)
![image](https://github.com/user-attachments/assets/4448cdf2-8023-4d2d-84b7-48f4cb99c4ca)

- 주문 ID로 주문 내역을 최신순으로 불러오는 기능을 구현했습니다.
    - 이 때, 본인의 주문 내역만 볼 수 있도록 이메일을 통해 검증했습니다.
![image](https://github.com/user-attachments/assets/b7e1974d-e5c5-4eb1-a9fb-8b0e4dc42301)
![image](https://github.com/user-attachments/assets/b139a333-2b7c-4e40-af75-b9441eb53a1c)

- 주문 내역 조회 방식에 따른 리다이렉트 분기 처리를 했습니다.
    - 이메일로 조회했을 경우에는 돌아가기 버튼을 누르면 이메일 입력 화면으로 리다이렉트 됩니다.
    - 주문 ID로 조회했을 경우에는 이메일로 주문 내역을 조회한 화면으로 리다이렉트 됩니다. 
![image](https://github.com/user-attachments/assets/a1ed4f7d-566a-45cb-a430-ba475246b29e)

#### 1. (작업 내용 간단 요약)
- /orders/search: 이메일 입력 화면
![image](https://github.com/user-attachments/assets/8bc04474-7524-4961-b1a0-6c5d5a18f5fc)

- /orders/email?li.wei@40example.com: li.wei@40example.com 사용자의 주문 내역 최신순 조회
![image](https://github.com/user-attachments/assets/f879e2f3-6933-4d4b-8943-f326cc37ff2c)

- /orders/id?email=li.wei@40example.com&orderId=7: li.wei@40example.com 사용자의 7번 주문 조회
![image](https://github.com/user-attachments/assets/ca08a101-5e64-4938-9a67-2bcd803da811)

## 💬 리뷰
- 입력에 대한 예외처리는 controller에서 하는 게 맞다고 생각해서 작업을 진행했는데, 예외처리가 많아질 경우에는 해당 부분을 분리해서 controller 예외처리 클래스를 따로 만드는 것이 낫나요? 그렇다면, 어떤 걸 활용해서 controller 공통 예외처리를 할 수 있을까요?
