### PR TITLE
주문 내역 -> 주문 상세 페이지 연동, 페이징 처리 UI 개선

### DIFF
--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -135,12 +135,39 @@
     </tbody>
   </table>
 
-  <div class="pagination" style="text-align: center; margin-top: 20px;" th:if="${totalPages > 1}">
-    <div style="display: inline-block;">
-      <a th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+  <div class="pagination" th:if="${totalPages > 1}" style="text-align: center; margin-top: 20px;">
+    <div style="display: flex; justify-content: center; gap: 6px; flex-wrap: wrap; min-height: 40px;">
+
+      <!-- 첫 페이지로 이동 -->
+      <a th:if="${totalPages > 5 and currentPage > 0}"
+         th:href="@{/orders/email(email=${email}, page=0)}"
+         style="min-width: 30px; text-align: center;">&laquo;</a>
+
+      <!-- 이전 페이지로 이동 -->
+      <a th:if="${totalPages > 5 and currentPage > 0}"
+         th:href="@{/orders/email(email=${email}, page=${currentPage - 1})}"
+         style="min-width: 30px; text-align: center;">&lt;</a>
+
+      <!-- 페이지 번호 리스트 (±2 범위 또는 전체 페이지) -->
+      <!-- 페이지 번호 범위: 최대 5개 (currentPage 중심) -->
+      <a th:each="i : ${#numbers.sequence(
+                currentPage - 2 > 0 ? currentPage - 2 : 0,
+                currentPage + 2 < totalPages ? currentPage + 2 : totalPages - 1)}"
          th:href="@{/orders/email(email=${email}, page=${i})}"
          th:text="${i + 1}"
-         th:classappend="${i == currentPage} ? ' button' : ''"></a>
+         th:classappend="${i == currentPage} ? ' button' : ''"
+         style="min-width: 30px; text-align: center;"></a>
+
+      <!-- 다음 페이지로 이동 -->
+      <a th:if="${totalPages > 5 and currentPage < totalPages - 1}"
+         th:href="@{/orders/email(email=${email}, page=${currentPage + 1})}"
+         style="min-width: 30px; text-align: center;">&gt;</a>
+
+      <!-- 마지막 페이지로 이동 -->
+      <a th:if="${totalPages > 5 and currentPage < totalPages - 1}"
+         th:href="@{/orders/email(email=${email}, page=${totalPages - 1})}"
+         style="min-width: 30px; text-align: center;">&raquo;</a>
+
     </div>
   </div>
 

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -132,7 +132,7 @@
         th:onclick="|location.href='/orders/${order.getId()}'|"
         style="cursor: pointer;">
 
-    <td th:text="${order.getId()}"></td>
+      <td th:text="${order.getId()}"></td>
       <td th:text="${order.getAddress()}"></td>
       <td th:text="${order.getZipcode()}"></td>
       <td th:text="${order.getTotalPrice()}"></td>
@@ -147,32 +147,31 @@
         style="display: flex; justify-content: center; gap: 6px; flex-wrap: wrap; min-height: 40px;">
 
       <!-- 첫 페이지로 이동 -->
-      <a th:if="${totalPages > 5 and currentPage > 0}"
+      <a th:if="${currentPage > 0}"
          th:href="@{/orders/email(email=${email}, page=0)}"
          style="min-width: 30px; text-align: center;">&laquo;</a>
 
       <!-- 이전 페이지로 이동 -->
-      <a th:if="${totalPages > 5 and currentPage > 0}"
+      <a th:if="${currentPage > 0}"
          th:href="@{/orders/email(email=${email}, page=${currentPage - 1})}"
          style="min-width: 30px; text-align: center;">&lt;</a>
 
-      <!-- 페이지 번호 리스트 (±2 범위 또는 전체 페이지) -->
-      <!-- 페이지 번호 범위: 최대 5개 (currentPage 중심) -->
+      <!-- 페이지 번호 슬라이딩 (처음 3페이지는 0부터 고정, 그 이후는 슬라이딩) -->
       <a th:each="i : ${#numbers.sequence(
-                currentPage - 2 > 0 ? currentPage - 2 : 0,
-                currentPage + 2 < totalPages ? currentPage + 2 : totalPages - 1)}"
+            currentPage <= 2 ? 0 : (currentPage + 2 >= totalPages ? totalPages - 5 : currentPage - 2),
+            currentPage <= 2 ? (totalPages < 5 ? totalPages - 1 : 4) : (currentPage + 2 >= totalPages ? totalPages - 1 : currentPage + 2))}"
          th:href="@{/orders/email(email=${email}, page=${i})}"
          th:text="${i + 1}"
          th:classappend="${i == currentPage} ? ' button' : ''"
          style="min-width: 30px; text-align: center;"></a>
 
       <!-- 다음 페이지로 이동 -->
-      <a th:if="${totalPages > 5 and currentPage < totalPages - 1}"
+      <a th:if="${currentPage < totalPages - 1}"
          th:href="@{/orders/email(email=${email}, page=${currentPage + 1})}"
          style="min-width: 30px; text-align: center;">&gt;</a>
 
       <!-- 마지막 페이지로 이동 -->
-      <a th:if="${totalPages > 5 and currentPage < totalPages - 1}"
+      <a th:if="${currentPage < totalPages - 1}"
          th:href="@{/orders/email(email=${email}, page=${totalPages - 1})}"
          style="min-width: 30px; text-align: center;">&raquo;</a>
 

--- a/src/main/resources/templates/view_orders.html
+++ b/src/main/resources/templates/view_orders.html
@@ -72,6 +72,10 @@
       background-color: #f0f0f0;
     }
 
+    tr:hover {
+      background-color: #f9f9f9;
+    }
+
     a.button {
       display: inline-block;
       margin-top: 20px;
@@ -124,8 +128,11 @@
     </tr>
     </thead>
     <tbody>
-    <tr th:each="order : ${orders}">
-      <td th:text="${order.getId()}"></td>
+    <tr th:each="order : ${orders}"
+        th:onclick="|location.href='/orders/${order.getId()}'|"
+        style="cursor: pointer;">
+
+    <td th:text="${order.getId()}"></td>
       <td th:text="${order.getAddress()}"></td>
       <td th:text="${order.getZipcode()}"></td>
       <td th:text="${order.getTotalPrice()}"></td>
@@ -136,7 +143,8 @@
   </table>
 
   <div class="pagination" th:if="${totalPages > 1}" style="text-align: center; margin-top: 20px;">
-    <div style="display: flex; justify-content: center; gap: 6px; flex-wrap: wrap; min-height: 40px;">
+    <div
+        style="display: flex; justify-content: center; gap: 6px; flex-wrap: wrap; min-height: 40px;">
 
       <!-- 첫 페이지로 이동 -->
       <a th:if="${totalPages > 5 and currentPage > 0}"


### PR DESCRIPTION
## ✨ 설명
- #24 
- 전체 주문 내역에서 특정 주문 내역을 클릭하면 상세 페이지로 이동하도록 처리했습니다.
- 전체 주문 내역 페이징 처리 UI를 개선했습니다.
    - 화살표 UI를 추가해 맨 앞 페이지, 이전 페이지, 다음 페이지, 맨 뒤 페이지로 이동 가능하게 UI를 개선했습니다.  

#### 1. (작업 내용 간단 요약)
![image](https://github.com/user-attachments/assets/eb1e7188-b791-4dd0-8d0a-0580a6be7725)