### PR TITLE
[test] productService 테스트 코드 추가

### DIFF
--- a/src/main/java/com/example/gridscircles/domain/product/controller/AdminProductController.java
+++ b/src/main/java/com/example/gridscircles/domain/product/controller/AdminProductController.java
@@ -109,7 +109,7 @@ public class AdminProductController {
             return "view_save_products";
         }
 
-        productService.updateProduct(productUpdateRequest, ProductId);
+        productService.updateProduct(productUpdateRequest);
 
         return "redirect:/admin/products/" + ProductId;
     }

--- a/src/main/java/com/example/gridscircles/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/gridscircles/domain/product/service/ProductService.java
@@ -53,9 +53,9 @@ public class ProductService {
     }
 
     @Transactional
-    public Product updateProduct(ProductUpdateRequest productUpdateRequest, Long id) {
+    public void updateProduct(ProductUpdateRequest productUpdateRequest) {
 
-        Product originProduct =  productRepository.findById(id)
+        Product originProduct =  productRepository.findById(productUpdateRequest.getId())
             .orElseThrow(() -> new NoSuchElementException("상품 없음 오류 ! "));
 
         byte [] decodeImage;
@@ -72,7 +72,6 @@ public class ProductService {
 
         originProduct.updateProduct(productUpdateRequest,decodeImage);
 
-        return originProduct;
     }
 
 

--- a/src/main/resources/templates/view_save_products.html
+++ b/src/main/resources/templates/view_save_products.html
@@ -77,7 +77,7 @@
          th:object="${productForm}"
          method="post" enctype="multipart/form-data">
     <div th:if="${!isNew}">
-      <input type="hidden" id="productId"  th:value="${productForm.id}"  />
+      <input type="hidden" id="productId"  th:value="${productForm.id}" name="id"  />
       <input type="hidden" name="base64EncodeImage" th:value="${productForm.base64EncodeImage}" />
       <input type="hidden" name="contentType" th:value="${productForm.contentType}" />
     </div>

--- a/src/test/java/com/example/gridscircles/domain/product/service/ProductServiceTests.java
+++ b/src/test/java/com/example/gridscircles/domain/product/service/ProductServiceTests.java
@@ -1,0 +1,229 @@
+package com.example.gridscircles.domain.product.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.gridscircles.domain.product.dto.ProductCreateRequest;
+import com.example.gridscircles.domain.product.dto.ProductResponse;
+import com.example.gridscircles.domain.product.dto.ProductUpdateRequest;
+import com.example.gridscircles.domain.product.entity.Product;
+import com.example.gridscircles.domain.product.enums.Category;
+import com.example.gridscircles.domain.product.repository.ProductRepository;
+import java.util.Base64;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+@DisplayName("Product Service 테스트")
+class ProductServiceTests {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("상품 등록 테스트")
+    void saveProductTest() throws Exception {
+
+        MockMultipartFile mockFile =
+            new MockMultipartFile("image_name","origin_image.jpg" ,"image/jpeg", "image.jpg".getBytes());
+
+        ProductCreateRequest productCreateRequest = ProductCreateRequest.builder()
+            .name("상품명")
+            .category(Category.DRINK)
+            .price("1,000")
+            .description("설명")
+            .file(mockFile)
+            .build();
+
+        Product savedProduct = productService.saveProduct(productCreateRequest);
+
+        assertThat(savedProduct.getName()).isEqualTo(productCreateRequest.getName());
+        assertThat(savedProduct.getCategory()).isEqualTo(productCreateRequest.getCategory());
+        assertThat(savedProduct.getPrice()).isEqualTo(1000);
+        assertThat(savedProduct.getDescription()).isEqualTo(productCreateRequest.getDescription());
+        assertThat(savedProduct.getImage()).isEqualTo(mockFile.getBytes());
+        assertThat(savedProduct.getContentType()).isEqualTo(mockFile.getContentType());
+        assertThat(savedProduct.getDel_yn()).isEqualTo("N");
+    }
+
+    @Test
+    @DisplayName("상품 상세 조회 테스트")
+    void findByIdProductTest() throws Exception {
+
+        MockMultipartFile mockFile =
+            new MockMultipartFile("image_name","origin_image.jpg" ,"image/jpeg", "image.jpg".getBytes());
+
+        Product product = Product.builder()
+                            .name("상품명")
+                            .description("상품설명")
+                            .price(1000)
+                            .category(Category.DRINK)
+                            .image(mockFile.getBytes())
+                            .contentType(mockFile.getContentType())
+                            .del_yn("N")
+                            .build();
+
+        productRepository.save(product);
+
+        ProductResponse productResponse = productService.findProductById(product.getId());
+
+        assertThat(productResponse.getName()).isEqualTo(product.getName());
+        assertThat(productResponse.getDescription()).isEqualTo(product.getDescription());
+        assertThat(productResponse.getPrice()).isEqualTo("1,000");
+        assertThat(productResponse.getCategory()).isEqualTo(product.getCategory());
+        assertThat(productResponse.getBase64EncodeImage()).isEqualTo(Base64.getEncoder().encodeToString(product.getImage()));
+        assertThat(productResponse.getContentType()).isEqualTo(product.getContentType());
+    }
+
+    @Test
+    @DisplayName("상품 삭제 테스트")
+    void deleteProductByIdTest() throws Exception {
+
+        MockMultipartFile mockFile =
+            new MockMultipartFile("image_name","origin_image.jpg" ,"image/jpeg", "image.jpg".getBytes());
+
+        Product product = Product.builder()
+            .name("상품명")
+            .description("상품설명")
+            .price(1000)
+            .category(Category.DRINK)
+            .image(mockFile.getBytes())
+            .contentType(mockFile.getContentType())
+            .del_yn("N")
+            .build();
+
+        productRepository.save(product);
+
+        productService.deleteProductById(product.getId());
+
+        Optional<Product> optionalProduct = productRepository.findById(product.getId());
+        assertThat(optionalProduct.isPresent()).isTrue();
+
+        Product deletedProduct = optionalProduct.get();
+
+        assertThat(deletedProduct.getName()).isEqualTo(product.getName());
+        assertThat(deletedProduct.getDescription()).isEqualTo(product.getDescription());
+        assertThat(deletedProduct.getPrice()).isEqualTo(product.getPrice());
+        assertThat(deletedProduct.getCategory()).isEqualTo(product.getCategory());
+        assertThat(deletedProduct.getImage()).isEqualTo(product.getImage());
+        assertThat(deletedProduct.getContentType()).isEqualTo(product.getContentType());
+        assertThat(deletedProduct.getDel_yn()).isEqualTo("Y");
+    }
+
+    @Nested
+    @DisplayName("상품 수정 테스트")
+    class updateProductTests {
+
+        @Test
+        @DisplayName("상품 수정 테스트- 이미지 업로드 x")
+        void updateProductTestWithoutImage() throws Exception {
+
+            MockMultipartFile mockFile =
+                new MockMultipartFile("image_name", "origin_image.jpg", "image/jpeg",
+                    "image.jpg".getBytes());
+
+            Product product = Product.builder()
+                .name("상품명")
+                .description("상품설명")
+                .price(1000)
+                .category(Category.DRINK)
+                .image(mockFile.getBytes())
+                .contentType(mockFile.getContentType())
+                .del_yn("N")
+                .build();
+
+            productRepository.save(product);
+
+            MockMultipartFile emptyFile = new MockMultipartFile("file", "", "image/jpeg", new byte[0]);
+
+            ProductUpdateRequest productUpdateRequest = ProductUpdateRequest.builder()
+                .id(product.getId())
+                .name("상품명 수")
+                .description("상품설정 수정")
+                .price("2000")
+                .category(Category.BREAD)
+                .file(emptyFile)
+                .base64EncodeImage(Base64.getEncoder().encodeToString(emptyFile.getBytes()))
+                .contentType(emptyFile.getContentType())
+                .build();
+
+            productService.updateProduct(productUpdateRequest);
+
+            Optional<Product> optionalProduct = productRepository.findById(product.getId());
+            assertThat(optionalProduct.isPresent()).isTrue();
+
+            Product updatedProduct = optionalProduct.get();
+
+            assertThat(updatedProduct.getName()).isEqualTo(productUpdateRequest.getName());
+            assertThat(updatedProduct.getCategory()).isEqualTo(productUpdateRequest.getCategory());
+            assertThat(updatedProduct.getPrice()).isEqualTo(2000);
+            assertThat(updatedProduct.getDescription()).isEqualTo(productUpdateRequest.getDescription());
+            assertThat(updatedProduct.getImage()).isEqualTo(Base64.getDecoder().decode(productUpdateRequest.getBase64EncodeImage()));
+            assertThat(updatedProduct.getContentType()).isEqualTo(productUpdateRequest.getContentType());
+            assertThat(updatedProduct.getDel_yn()).isEqualTo("N");
+
+        }
+
+        @Test
+        @DisplayName("상품 수정 테스트 - 이미지 업로드 o")
+        void updateProductTestWithImage() throws Exception {
+
+            MockMultipartFile mockFile =
+                new MockMultipartFile("image_name", "origin_image.jpg", "image/jpeg",
+                    "image.jpg".getBytes());
+
+            Product product = Product.builder()
+                .name("상품명")
+                .description("상품설명")
+                .price(1000)
+                .category(Category.DRINK)
+                .image(mockFile.getBytes())
+                .contentType(mockFile.getContentType())
+                .del_yn("N")
+                .build();
+
+            productRepository.save(product);
+
+            MockMultipartFile updatedFile =
+                new MockMultipartFile("updated_name", "updated_image.png", "image/png",
+                    "image.jpg".getBytes() );
+
+            ProductUpdateRequest productUpdateRequest = ProductUpdateRequest.builder()
+                .id(product.getId())
+                .name("상품명 수")
+                .description("상품설정 수정")
+                .price("2000")
+                .category(Category.BREAD)
+                .file(updatedFile)
+                .base64EncodeImage(Base64.getEncoder().encodeToString(mockFile.getBytes()))
+                .contentType(mockFile.getContentType())
+                .build();
+
+            productService.updateProduct(productUpdateRequest);
+
+            Optional<Product> optionalProduct = productRepository.findById(product.getId());
+            assertThat(optionalProduct.isPresent()).isTrue();
+
+            Product updatedProduct = optionalProduct.get();
+
+            assertThat(updatedProduct.getName()).isEqualTo(productUpdateRequest.getName());
+            assertThat(updatedProduct.getCategory()).isEqualTo(productUpdateRequest.getCategory());
+            assertThat(updatedProduct.getPrice()).isEqualTo(2000);
+            assertThat(updatedProduct.getDescription()).isEqualTo(productUpdateRequest.getDescription());
+            assertThat(updatedProduct.getImage()).isEqualTo(productUpdateRequest.getFile().getBytes());
+            assertThat(updatedProduct.getContentType()).isEqualTo(productUpdateRequest.getFile().getContentType());
+            assertThat(updatedProduct.getDel_yn()).isEqualTo("N");
+        }
+    }
+
+}


### PR DESCRIPTION
#38 

## ✨ 설명

ProductService 레이어 테스트 코드를 작성하였습니다. 

#### 1. (작업 내용 간단 요약)

- 상품 수정 시, 이미지를 새로 첨부하는 경우와 첨부하지않은 경우를 나눠서 테스트하였습니다. 

```java
@Nested
    @DisplayName("상품 수정 테스트")
    class updateProductTests {
``` 

- 서비스 레이어에서 상품 수정 시 return 타입과 파라미터를 변경하였습니다. 
 - return 타입 변경 : Product -> void (호출시 해당 객체를 사용하는 곳이 없기때문에 void로 변경) 
 - 파라미터 변경 : (ProductUpdateRequest productUpdateRequest, Long id) 에서 id 파라미터를 삭제하였습니다.
   - 수정 화면에서 productUpdateRequest에 id값을 서버에 담아서 넘겨주게 구현한 후 삭제하였습니다. 
   - 그에 따른 html , controller를 수정하였습니다. 


```java
 @Transactional
    public void updateProduct(ProductUpdateRequest productUpdateRequest) {

        Product originProduct =  productRepository.findById(productUpdateRequest.getId())
            .orElseThrow(() -> new NoSuchElementException("상품 없음 오류 ! "));

        byte [] decodeImage;

        try{
            if (productUpdateRequest.getFile().isEmpty()){
                decodeImage = Base64.getDecoder().decode(productUpdateRequest.getBase64EncodeImage());
            }else{
                decodeImage = productUpdateRequest.getFile().getBytes();
            }
        } catch (IOException e) {
            throw new RuntimeException(e);
        }

        originProduct.updateProduct(productUpdateRequest,decodeImage);

    }
``` 

<br/>

## 💬 리뷰
- 정상 동작테스트만 구현하였는데, 예외 테스트도 구현하는 것이 좋을까요? 그렇다면 예외테스트 구현을 위해 각자 커스텀 예외 클래스를 생성해야할까요?



<br/>

## 🔗 참고


