### PR TITLE
[feat]: 관리자 주문 상세 페이지 -> 관리자용 주문 내역 리스트로 이동 버튼 추가 

### DIFF
--- a/src/main/java/com/example/gridscircles/domain/order/controller/AdminOrderController.java
+++ b/src/main/java/com/example/gridscircles/domain/order/controller/AdminOrderController.java
@@ -3,6 +3,7 @@ package com.example.gridscircles.domain.order.controller;
 
 import static java.util.List.of;
 
+import com.example.gridscircles.domain.order.dto.OrderDetailResponse;
 import com.example.gridscircles.domain.order.dto.OrdersSearchResponse;
 import com.example.gridscircles.domain.order.service.OrdersService;
 import java.util.List;
@@ -26,7 +27,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @RequiredArgsConstructor
 public class AdminOrderController {
 
-  private final OrdersService ordersService;
+    private final OrdersService ordersService;
 
 
     @GetMapping("/orders/list")
@@ -68,11 +69,10 @@ public class AdminOrderController {
     }
 
 
-    // 해당 주문의 상세페이지
-    @GetMapping("/{orderId}")
+    @GetMapping("/orders/{orderId}")
     public String viewOrderDetail(@PathVariable Long orderId, Model model) {
-        OrdersSearchResponse orderDetail = ordersService.readOrderById(orderId);
+        OrderDetailResponse orderDetail = ordersService.getOrderDetail(orderId);
         model.addAttribute("orderDetail", orderDetail);
-        return "view_orderDetail"; // 상세페이지 템플릿
+        return "view_orderDetail";
     }
 }

--- a/src/main/resources/templates/admin/view_orders.html
+++ b/src/main/resources/templates/admin/view_orders.html
@@ -117,7 +117,7 @@
     </thead>
     <tbody>
     <tr th:each="order : ${orders_list}" th:if="${orders_list != null}"
-        th:onclick="|location.href='/orders/${order.orderId}'|"
+        th:onclick="|location.href='/admin/orders/${order.orderId}'|"
         style="cursor: pointer;">
       <td th:text="${order.orderId}"></td>
       <td>

--- a/src/main/resources/templates/view_orderDetail.html
+++ b/src/main/resources/templates/view_orderDetail.html
@@ -163,7 +163,7 @@
         </button>
         <a sec:authorize="hasAuthority('ADMIN')"
            th:href="@{/admin/orders/list}"
-           class="btn btn-danger">
+           class="btn btn-dark bg-danger border-0">
           관리자 주문 목록
         </a>
       </div>

--- a/src/main/resources/templates/view_orderDetail.html
+++ b/src/main/resources/templates/view_orderDetail.html
@@ -1,5 +1,7 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      lang="ko">
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -159,6 +161,11 @@
             th:if="${orderDetail.getEditable()}">
           주문 취소
         </button>
+        <a sec:authorize="hasAuthority('ADMIN')"
+           th:href="@{/admin/orders/list}"
+           class="btn btn-danger">
+          관리자 주문 목록
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## ✨ 설명
* #57 
* 관리자 주문 상세 페이지 -> 관리자용 주문 내역 리스트로 이동 버튼 추가 

## 작업 내용

1. AdminOrderController 리팩토링
```java
@GetMapping("/orders/{orderId}")
public String viewOrderDetail(@PathVariable Long orderId, Model model) {
        OrderDetailResponse orderDetail = ordersService.getOrderDetail(orderId);
        model.addAttribute("orderDetail", orderDetail);
        return "view_orderDetail";
}
```

2. 뷰에 권한 체크 추가 후 버튼 보이게 작성

```java
 <a sec:authorize="hasAuthority('ADMIN')"
           th:href="@{/admin/orders/list}"
           class="btn btn-danger">
          관리자 주문 목록
</a>
```

3. 관리자 주문 내역 버튼 추가
![image](https://github.com/user-attachments/assets/83a12c30-fc71-4f76-a072-63e32a89e55c)

![image](https://github.com/user-attachments/assets/93f753a9-3d5d-4727-b364-54db5086bfc3)




## 💬 리뷰

버튼이 안이뻐서 css 살짝 수정할까 생각중입니다.
