### PR TITLE
[refactor] 주문 내역 조회 예외처리 적용

### DIFF
--- a/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
+++ b/src/main/java/com/example/gridscircles/domain/order/service/OrdersService.java
@@ -1,5 +1,6 @@
 package com.example.gridscircles.domain.order.service;
 
+import static com.example.gridscircles.global.exception.ErrorCode.NOT_FOUND_EMAIL;
 import static com.example.gridscircles.global.exception.ErrorCode.NOT_FOUND_ORDERS;
 import static com.example.gridscircles.global.exception.ErrorCode.NOT_FOUND_PRODUCT;
 
@@ -122,11 +123,19 @@ public class OrdersService {
     }
 
     public Page<Orders> getOrdersByEmail(String email, Pageable pageable) {
-        return ordersRepository.findByEmailOrderByCreatedAtDesc(email, pageable);
+        Page<Orders> orders = ordersRepository.findByEmailOrderByCreatedAtDesc(email, pageable);
+        if (orders.isEmpty()) {
+            throw new ErrorException(NOT_FOUND_EMAIL);
+        }
+        return orders;
     }
 
     public List<Orders> getOrderById(Long id, String email) {
-        return ordersRepository.findByIdAndEmailOrderByCreatedAt(id, email);
+        List<Orders> orders = ordersRepository.findByIdAndEmailOrderByCreatedAt(id, email);
+        if (orders.isEmpty()) {
+            throw new ErrorException(NOT_FOUND_ORDERS);
+        }
+        return orders;
     }
 
     private List<OrderProduct> createOrderProducts(List<CreateOrdersProductDto> productsDto,

--- a/src/main/java/com/example/gridscircles/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/gridscircles/global/exception/ErrorCode.java
@@ -15,11 +15,9 @@ public enum ErrorCode {
         "배송이 완료되었거나 주문이 취소된 상태는 취소할 수 없습니다."),
     NOT_UPDATABLE_ORDER(BAD_REQUEST, "ORDERS-003",
         "배송이 완료되었거나 주문이 취소된 상태는 수정할 수 없습니다."),
-
+    NOT_FOUND_EMAIL(NOT_FOUND, "ORDERS-004", "해당 이메일로 주문된 내역이 없습니다."),
     // Product
-    NOT_FOUND_PRODUCT(NOT_FOUND, "PRODUCT-001", "존재하지 않는 상품입니다.")
-    ;
-
+    NOT_FOUND_PRODUCT(NOT_FOUND, "PRODUCT-001", "존재하지 않는 상품입니다.");
 
     private final ErrorStatus errorStatus;
     private final String code;


### PR DESCRIPTION
## ✨ 설명
- #78
- 공통 예외처리 적용
    - 전체 주문 내역 조회
    - 특정 주문 내역 조회

#### 1. (작업 내용 간단 요약)
(작업한 부분 설명 및 코드와 이미지 첨부)
- 이메일로 주문된 내역이 없을 때, 예외처리
```
Page<Orders> orders = ordersRepository.findByEmailOrderByCreatedAtDesc(email, pageable);
    if (orders.isEmpty()) {
        throw new ErrorException(NOT_FOUND_EMAIL);
    }
```
- 주문 내역에서 주문 ID에 해당하는 주문이 없을 때, 예외처리
```
List<Orders> orders = ordersRepository.findByIdAndEmailOrderByCreatedAt(id, email);
    if (orders.isEmpty()) {
        throw new ErrorException(NOT_FOUND_ORDERS);
    }
```