### PR TITLE
[refactor] 안쓰는 생성자 삭제 및 loadUserByUsername 예외 처리 방식 수정

### DIFF
--- a/src/main/java/com/example/gridscircles/domain/admin/entitiy/Member.java
+++ b/src/main/java/com/example/gridscircles/domain/admin/entitiy/Member.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,12 +31,4 @@ public class Member {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    @Builder
-    public Member(Long id, String email, String password, Role role) {
-        this.id = id;
-        this.email = email;
-        this.password = password;
-        this.role = role;
-    }
 }

--- a/src/main/java/com/example/gridscircles/domain/admin/service/MemberService.java
+++ b/src/main/java/com/example/gridscircles/domain/admin/service/MemberService.java
@@ -8,7 +8,6 @@ import com.example.gridscircles.global.exception.ErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -18,7 +17,7 @@ public class MemberService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+    public UserDetails loadUserByUsername(String email) {
         return memberRepository.findByEmail(email)
             .map(m -> MemberDetails.builder()
                 .email(m.getEmail())


### PR DESCRIPTION
## ✨ 설명

* #86 



1. 필요없는 생성자 삭제, 클래스에 `@Builder` 붙이기
```java
@Entity
@Getter
@Builder
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@AllArgsConstructor(access = AccessLevel.PRIVATE)
public class Member {

    @Id
    @Column(name = "member_id")
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column(nullable = false, unique = true)
    private String email;

    @Column(nullable = false)
    private String password;

    @Column(nullable = false)
    @Enumerated(EnumType.STRING)
    private Role role;
}
```

2. `UsernameNotFoundException` 삭제

```java
 @Override
 public UserDetails loadUserByUsername(String email) {
        return memberRepository.findByEmail(email)
            .map(m -> MemberDetails.builder()
                .email(m.getEmail())
                .password(m.getPassword())
                .role(m.getRole())
                .build()
            )
            .orElseThrow(() -> new ErrorException(NOT_FOUND_MEMBER));
}
```


## 💬 리뷰

## 🔗 참고

