### PR TITLE
[feat] : String 길이 체크 유효성 추가 

### DIFF
--- a/src/main/java/com/example/gridscircles/domain/product/dto/ProductCreateRequest.java
+++ b/src/main/java/com/example/gridscircles/domain/product/dto/ProductCreateRequest.java
@@ -1,8 +1,10 @@
 package com.example.gridscircles.domain.product.dto;
 
 import com.example.gridscircles.domain.product.enums.Category;
+import com.example.gridscircles.global.annotation.ByteSize;
 import com.example.gridscircles.global.annotation.ProductValidFile;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,14 +17,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class ProductCreateRequest {
 
     @NotBlank(message = "상품명은 필수입니다.")
+    @ByteSize(max = 255)
     private String name;
 
     private Category category;
 
     @NotBlank(message = "상품설명은 필수입니다.")
+    @ByteSize(max = 255)
     private String description;
 
     @NotBlank(message = "가격 입력은 필수입니다.")
+    @ByteSize(max = 255)
     private String price;
 
     @ProductValidFile

--- a/src/main/java/com/example/gridscircles/domain/product/dto/ProductSearchResponse.java
+++ b/src/main/java/com/example/gridscircles/domain/product/dto/ProductSearchResponse.java
@@ -14,17 +14,17 @@ public class ProductSearchResponse {
     private String name;
     private String description;
     private Integer price;
-    private String del_yn;
+    private String delYN;
     private Category category;
 
     @Builder
     public ProductSearchResponse(Long id, String name, String description,
-        Integer price, String del_yn, Category category) {
+        Integer price, String delYN, Category category) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.price = price;
-        this.del_yn = del_yn;
+        this.delYN = delYN;
         this.category = category;
     }
 }

--- a/src/main/java/com/example/gridscircles/domain/product/entity/Product.java
+++ b/src/main/java/com/example/gridscircles/domain/product/entity/Product.java
@@ -48,11 +48,11 @@ public class Product extends BaseEntity {
     @Column(nullable = false)
     private String contentType;
 
-    @Column(nullable = false)
-    private String del_yn;
+    @Column(name = "del_yn" ,nullable = false)
+    private String delYN;
 
     public void deleted() {
-        this.del_yn = "Y";
+        this.delYN = "Y";
     }
 
     public void updateProduct(ProductUpdateRequest productUpdateRequest, byte[] image) {
@@ -104,13 +104,13 @@ public class Product extends BaseEntity {
 
     @Builder
     public Product(String name, Category category, String description, Integer price, byte[] image,
-        String contentType, String del_yn) {
+        String contentType, String delYN) {
         this.name = name;
         this.category = category;
         this.description = description;
         this.price = price;
         this.image = image;
         this.contentType = contentType;
-        this.del_yn = del_yn;
+        this.delYN = delYN;
     }
 }

--- a/src/main/java/com/example/gridscircles/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/gridscircles/domain/product/repository/ProductRepository.java
@@ -10,11 +10,11 @@ import org.springframework.data.repository.query.Param;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
     // 1. 삭제되지 않은 상품 중에서, 상품명에 주어진 name을 포함하는 상품을 페이징 처리
-    @Query("SELECT p FROM Product p WHERE p.del_yn = 'N' AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+    @Query("SELECT p FROM Product p WHERE p.delYN = 'N' AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))")
     Page<Product> findNonDeletedProductsByName(@Param("name") String name, Pageable pageable);
 
     // 2. 삭제되지 않은 상품 전체를 페이징 처리
-    @Query("SELECT p FROM Product p WHERE p.del_yn = 'N'")
+    @Query("SELECT p FROM Product p WHERE p.delYN = 'N'")
     Page<Product> findNonDeletedProducts(Pageable pageable);
 
     Page<Product> findAll(Pageable pageable);

--- a/src/main/java/com/example/gridscircles/domain/product/util/mapper/ProductMapper.java
+++ b/src/main/java/com/example/gridscircles/domain/product/util/mapper/ProductMapper.java
@@ -24,7 +24,7 @@ public class ProductMapper {
                 .price(price)
                 .image(productCreateRequest.getFile().getBytes())
                 .contentType(productCreateRequest.getFile().getContentType())
-                .del_yn("N")
+                .delYN("N")
                 .build();
         } catch (IOException e) {
             throw new ErrorException(ErrorCode.NOT_READABLE_FILE);
@@ -68,7 +68,7 @@ public class ProductMapper {
             .name(product.getName())
             .description(product.getDescription())
             .price(product.getPrice())
-            .del_yn(product.getDel_yn())
+            .delYN(product.getDelYN())
             .category(product.getCategory())
             .build();
     }

--- a/src/main/java/com/example/gridscircles/global/annotation/ByteSize.java
+++ b/src/main/java/com/example/gridscircles/global/annotation/ByteSize.java
@@ -1,0 +1,27 @@
+package com.example.gridscircles.global.annotation;
+
+
+import com.example.gridscircles.global.validator.ByteSizeValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Constraint(validatedBy = ByteSizeValidator.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ByteSize {
+
+    String message() default "바이트 길이가 허용 범위를 초과했습니다.";
+
+    int max();
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/src/main/java/com/example/gridscircles/global/validator/ByteSizeValidator.java
+++ b/src/main/java/com/example/gridscircles/global/validator/ByteSizeValidator.java
@@ -1,0 +1,26 @@
+package com.example.gridscircles.global.validator;
+
+import com.example.gridscircles.global.annotation.ByteSize;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.nio.charset.StandardCharsets;
+
+public class ByteSizeValidator implements ConstraintValidator<ByteSize, String> {
+
+    private int max;
+
+    @Override
+    public void initialize(ByteSize constraintAnnotation) {
+        this.max = constraintAnnotation.max();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
+        if(value == null){
+            return true;
+        }
+        int byteLength = value.getBytes(StandardCharsets.UTF_8).length;
+
+        return byteLength <= max;
+    }
+}

--- a/src/test/java/com/example/gridscircles/domain/order/service/OrdersServiceTests.java
+++ b/src/test/java/com/example/gridscircles/domain/order/service/OrdersServiceTests.java
@@ -64,7 +64,7 @@ class OrdersServiceTests {
             .description("사바하 커피는 진자 맛있어요!")
             .contentType("image/jpeg")
             .image((name + "-img").getBytes())
-            .del_yn("N")
+            .delYN("N")
             .build();
         return productRepository.save(product);
     }
@@ -285,7 +285,7 @@ class OrdersServiceTests {
                 .description("맛있어요!")
                 .contentType("image/jpeg")
                 .image(dummyImage1)
-                .del_yn("Y")
+                .delYN("Y")
                 .build();
             productRepository.save(product);
 

--- a/src/test/java/com/example/gridscircles/domain/product/service/ProductServiceTests.java
+++ b/src/test/java/com/example/gridscircles/domain/product/service/ProductServiceTests.java
@@ -57,7 +57,7 @@ class ProductServiceTests {
         assertThat(savedProduct.getDescription()).isEqualTo(productCreateRequest.getDescription());
         assertThat(savedProduct.getImage()).isEqualTo(mockFile.getBytes());
         assertThat(savedProduct.getContentType()).isEqualTo(mockFile.getContentType());
-        assertThat(savedProduct.getDel_yn()).isEqualTo("N");
+        assertThat(savedProduct.getDelYN()).isEqualTo("N");
     }
 
     @Test
@@ -98,7 +98,7 @@ class ProductServiceTests {
             .category(Category.DRINK)
             .image(mockFile.getBytes())
             .contentType(mockFile.getContentType())
-            .del_yn("N")
+            .delYN("N")
             .build();
         productRepository.save(product);
 
@@ -147,7 +147,7 @@ class ProductServiceTests {
             .category(Category.DRINK)
             .image(mockFile.getBytes())
             .contentType(mockFile.getContentType())
-            .del_yn("N")
+            .delYN("N")
             .build();
         productRepository.save(product);
 
@@ -164,7 +164,7 @@ class ProductServiceTests {
         assertThat(deletedProduct.getCategory()).isEqualTo(product.getCategory());
         assertThat(deletedProduct.getImage()).isEqualTo(product.getImage());
         assertThat(deletedProduct.getContentType()).isEqualTo(product.getContentType());
-        assertThat(deletedProduct.getDel_yn()).isEqualTo("Y");
+        assertThat(deletedProduct.getDelYN()).isEqualTo("Y");
     }
 
     @Nested
@@ -185,7 +185,7 @@ class ProductServiceTests {
                 .category(Category.DRINK)
                 .image(mockFile.getBytes())
                 .contentType(mockFile.getContentType())
-                .del_yn("N")
+                .delYN("N")
                 .build();
             productRepository.save(product);
 
@@ -218,7 +218,7 @@ class ProductServiceTests {
                 Base64.getDecoder().decode(productUpdateRequest.getBase64EncodeImage()));
             assertThat(updatedProduct.getContentType()).isEqualTo(
                 productUpdateRequest.getContentType());
-            assertThat(updatedProduct.getDel_yn()).isEqualTo("N");
+            assertThat(updatedProduct.getDelYN()).isEqualTo("N");
         }
 
         @Test
@@ -235,7 +235,7 @@ class ProductServiceTests {
                 .category(Category.DRINK)
                 .image(mockFile.getBytes())
                 .contentType(mockFile.getContentType())
-                .del_yn("N")
+                .delYN("N")
                 .build();
             productRepository.save(product);
 
@@ -268,7 +268,7 @@ class ProductServiceTests {
                 productUpdateRequest.getFile().getBytes());
             assertThat(updatedProduct.getContentType()).isEqualTo(
                 productUpdateRequest.getFile().getContentType());
-            assertThat(updatedProduct.getDel_yn()).isEqualTo("N");
+            assertThat(updatedProduct.getDelYN()).isEqualTo("N");
         }
 
         @Test
@@ -321,7 +321,7 @@ class ProductServiceTests {
                 .category(Category.DRINK)
                 .image(mockFile.getBytes())
                 .contentType(mockFile.getContentType())
-                .del_yn("N")
+                .delYN("N")
                 .build();
             productRepository.save(product);
 

--- a/src/test/java/com/example/gridscircles/domain/product/service/ProductsServiceTests.java
+++ b/src/test/java/com/example/gridscircles/domain/product/service/ProductsServiceTests.java
@@ -47,7 +47,7 @@ public class ProductsServiceTests {
                 .description("맛있어요!")
                 .contentType("image/jpeg")
                 .image(dummyImage1)
-                .del_yn("N")
+                .delYN("N")
                 .build();
             Product product2 = Product.builder()
                 .name("초코라떼")
@@ -56,7 +56,7 @@ public class ProductsServiceTests {
                 .description("맛있어요!!")
                 .contentType("image/jpeg")
                 .image(dummyImage2)
-                .del_yn("N")
+                .delYN("N")
                 .build();
             Product product3 = Product.builder()
                 .name("아메리카노")
@@ -65,7 +65,7 @@ public class ProductsServiceTests {
                 .description("맛있어요!!!")
                 .contentType("image/jpeg")
                 .image(dummyImage3)
-                .del_yn("Y")
+                .delYN("Y")
                 .build();
             productRepository.saveAll(List.of(product1, product2, product3));
 


### PR DESCRIPTION
#87 

## ✨ 설명

- 엔티티의 필드 사이즈에 따라 입력값들의 사이즈를 제한해야함. 

- 하지만 아래와 같이 유효성 체크를 하게 되면 한글은 3byte, 영어는 1byte로
 해당 로직을 통과해도 db 입력 시 오류가 날 수 있음 
```java
@Size(max =255)
``` 
- 따라서 byte수로 더 정확히 체크할 수 있도록 아래처럼 로직을 구현하였음
(커스텀 어노테이션 추가 @ByteSize ) 

```java
@Override
    public boolean isValid(String value, ConstraintValidatorContext constraintValidatorContext) {
        if(value == null){
            return true;
        }
        int byteLength = value.getBytes(StandardCharsets.UTF_8).length;

        return byteLength <= max;
    }
``` 

- 적용 코드 (ProductCreateRequest) 

```java
 @NotBlank(message = "상품명은 필수입니다.")
    @ByteSize(max = 255)
    private String name;
``` 

- 어노테이션은 아래와 같이 상황 별 적용이 가능함 

 @ByteSize(max = 255, message = "메세지 커스텀 가능")

- 적용 화면 

![image](https://github.com/user-attachments/assets/20849706-ca40-4df3-9206-e7274ce3fd37)




<br/>

## 💬 리뷰

- 아직 필드 사이즈 유효성 체크를 안하신분이라면 적용해보시길 권장합니다~!
